### PR TITLE
Migration:タグの付与テーブルにupdated_atは不要なので削除しました

### DIFF
--- a/migrations/20201115_1_tag_attachment_fix.sql
+++ b/migrations/20201115_1_tag_attachment_fix.sql
@@ -1,0 +1,12 @@
+alter table tags_posts_attachment drop column updated_at;
+
+insert into
+    migration_histories
+(
+    created_at,
+    migration_name
+)
+values (
+     current_timestamp,
+     '20201115_1_tag_attachment_fix.sql'
+);


### PR DESCRIPTION
## やったこと
タグの付与テーブルからupdated_atを削除しました

## やってないこと

## その他
