### PR TITLE
Backend タグのテーブルの制約変更

### DIFF
--- a/migrations/20210505_1_fix_fk_tag_posts_attachment.sql
+++ b/migrations/20210505_1_fix_fk_tag_posts_attachment.sql
@@ -1,0 +1,16 @@
+alter table tags_posts_attachments drop constraint fk_post_id;
+alter table tags_posts_attachments add constraint fk_post_id foreign key (post_id) references posts(id) on delete cascade;
+alter table tags_posts_attachments drop constraint fk_tag_id;
+alter table tags_posts_attachments add constraint fk_tag_id foreign key (tag_id) references tags(id) on delete cascade;
+
+insert into
+	migration_histories 
+(
+	created_at,
+	migration_name
+)
+values
+(
+	current_timestamp,
+	'20210505_1_fix_fk_tag_posts_attachment.sql'
+)


### PR DESCRIPTION
## やったこと
`tags_posts_attachment` の制約を変更, ポスト/タグを削除した時に自動的に消されるようにしました

## やってないこと

## その他
